### PR TITLE
Bug goblins sin armadura

### DIFF
--- a/code/modules/clothing/rogueclothes/npc/goblin.dm
+++ b/code/modules/clothing/rogueclothes/npc/goblin.dm
@@ -1,10 +1,16 @@
+#define MOB_GOBLINS list(/datum/species/goblin,\
+						/datum/species/goblin/cave,\
+						/datum/species/goblin/moon,\
+						/datum/species/goblin/sea,\
+						/datum/species/goblin/hell)
+
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron/goblin
 	name = "goblin mail"
 	icon_state = "plate_armor_item"
 	item_state = "plate_armor"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
 	smeltresult = /obj/item/ingot/iron
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = MOB_GOBLINS
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|VITALS
 	sellprice = 0
 
@@ -14,7 +20,7 @@
 	item_state = "leather_armor"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
 	body_parts_covered = CHEST|GROIN|ARMS|VITALS
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = MOB_GOBLINS
 	sellprice = 0
 
 /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
@@ -22,7 +28,7 @@
 	icon_state = "cloth_armor"
 	item_state = "cloth_armor"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = MOB_GOBLINS
 	armor = null
 	sellprice = 0
 
@@ -31,7 +37,7 @@
 	icon_state = "leather_helm_item"
 	item_state = "leather_helm"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = MOB_GOBLINS
 	sellprice = 0
 
 /obj/item/clothing/head/roguetown/helmet/goblin
@@ -39,7 +45,9 @@
 	icon_state = "plate_helm_item"
 	item_state = "plate_helm"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = MOB_GOBLINS
 	body_parts_covered = HEAD|EARS|HAIR|EYES
 	sellprice = 0
 	smeltresult = /obj/item/ingot/iron
+
+#undef MOB_GOBLINS


### PR DESCRIPTION
Ahora los goblins de mazmorras y los spawneados tienen su armadura de cuero y su armadura de hierro cuando sean heavy.

Esto directamente hace que sean más fuertes, pero siempre fue intencionado. No más goblins desnudos.